### PR TITLE
Fix: 다크모드 문제 해결, 캐시 삭제 불필요

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>깡갤 번역기</title>
-    <link rel="stylesheet" href="styles.css">
+    <link rel="stylesheet" href="styles.css?v=241110f4">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -286,6 +286,6 @@
             <p>모든 페이지 내용의 소유권은 tincansimagine에게 있습니다.</p>
         </div>
     </div>
-    <script src="translator.js"></script>
+    <script src="translator.js?v=241110f4"></script>
 </body>
 </html>

--- a/translator.js
+++ b/translator.js
@@ -256,11 +256,6 @@ function initializeEventListeners() {
             }
         }
 
-        // Ctrl + D: 다크모드 토글
-        if (e.ctrlKey && e.key === 'd') {
-            e.preventDefault();
-            toggleTheme();
-        }
     });
 }
 


### PR DESCRIPTION
translator.js / initializeEventListeners() 내의 다크모드 단축키 등록 삭제 (이벤트 리스너 중복 등록으로 테마 변경이 2회 실행되는 문제)　
index.html / css와 js 부분에 ?v=버전코드 부여. 이후 업뎃시마다 해당 버전코드를 수정하면 사용자측에서의 캐시 삭제 필요 없음